### PR TITLE
Revise poisson_blend

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -66,7 +66,7 @@ def main(args):
         x_mask = x - x * mask + mpv * mask
         input = torch.cat((x_mask, mask), dim=1)
         output = model(input)
-        inpainted = poisson_blend(x, output, mask)
+        inpainted = poisson_blend(x_mask, output, mask)
         imgs = torch.cat((x, x_mask, inpainted), dim=0)
         save_image(imgs, args.output_img, nrow=3)
     print('output img was saved as %s.' % args.output_img)

--- a/train.py
+++ b/train.py
@@ -173,7 +173,7 @@ def main(args):
                         x_mask = x - x * mask + mpv * mask
                         input = torch.cat((x_mask, mask), dim=1)
                         output = model_cn(input)
-                        completed = poisson_blend(x, output, mask)
+                        completed = poisson_blend(x_mask, output, mask)
                         imgs = torch.cat((x.cpu(), x_mask.cpu(), completed.cpu()), dim=0)
                         imgpath = os.path.join(args.result_dir, 'phase_1', 'step%d.png' % pbar.n)
                         model_cn_path = os.path.join(args.result_dir, 'phase_1', 'model_cn_step%d' % pbar.n)
@@ -268,7 +268,7 @@ def main(args):
                         x_mask = x - x * mask + mpv * mask
                         input = torch.cat((x_mask, mask), dim=1)
                         output = model_cn(input)
-                        completed = poisson_blend(x, output, mask)
+                        completed = poisson_blend(x_mask, output, mask)
                         imgs = torch.cat((x.cpu(), x_mask.cpu(), completed.cpu()), dim=0)
                         imgpath = os.path.join(args.result_dir, 'phase_2', 'step%d.png' % pbar.n)
                         model_cd_path = os.path.join(args.result_dir, 'phase_2', 'model_cd_step%d' % pbar.n)
@@ -368,7 +368,7 @@ def main(args):
                         x_mask = x - x * mask + mpv * mask
                         input = torch.cat((x_mask, mask), dim=1)
                         output = model_cn(input)
-                        completed = poisson_blend(x, output, mask)
+                        completed = poisson_blend(x_mask, output, mask)
                         imgs = torch.cat((x.cpu(), x_mask.cpu(), completed.cpu()), dim=0)
                         imgpath = os.path.join(args.result_dir, 'phase_3', 'step%d.png' % pbar.n)
                         model_cn_path = os.path.join(args.result_dir, 'phase_3', 'model_cn_step%d' % pbar.n)

--- a/utils.py
+++ b/utils.py
@@ -158,6 +158,7 @@ def poisson_blend(x, output, mask):
         xmin, xmax = min(xs), max(xs)
         ymin, ymax = min(ys), max(ys)
         center = ((xmax + xmin) // 2, (ymax + ymin) // 2)
+        dstimg = cv2.inpaint(dstimg, msk[:, :, 0], 1, cv2.INPAINT_TELEA)
         out = cv2.seamlessClone(srcimg, dstimg, msk, center, cv2.NORMAL_CLONE)
         out = out[:, :, [2, 1, 0]]
         out = transforms.functional.to_tensor(out)


### PR DESCRIPTION
Thank you very much for your clear GLCIC-PyTorch implementation.
As salbeira pointed out in the issue #16, the original image x should not be used in poisson_blend.

It turns out that the original lua implementation calls cv2.inpaint before cv2.seamlessClone.
https://github.com/satoshiiizuka/siggraph2017_inpainting/blob/master/inpaint.lua#L111

A combination of revised poisson_blend and x_mask works well and it does not use the original image.